### PR TITLE
docs: instruct setting startTerminal/startIde in settings during initialization

### DIFF
--- a/openclaw-skill/SKILL.md
+++ b/openclaw-skill/SKILL.md
@@ -33,6 +33,21 @@ mkdir -p .iloom
 echo '{"mainBranch": "main"}' > .iloom/settings.json
 ```
 
+Also create `.iloom/settings.local.json` with AI-agent-friendly defaults to prevent iloom from launching terminal windows and IDE on loom creation:
+
+```json
+{
+  "workflows": {
+    "issue": {
+      "startTerminal": false,
+      "startIde": false
+    }
+  }
+}
+```
+
+These settings eliminate the need for `--no-code`/`--no-terminal` flags on every command, though the flags are still passed as a safety net in the patterns below.
+
 See `{baseDir}/references/initialization.md` for the complete settings schema, all configuration options, and example configurations.
 
 **Alternative: Interactive wizard (for humans at a terminal)**

--- a/openclaw-skill/references/initialization.md
+++ b/openclaw-skill/references/initialization.md
@@ -56,11 +56,16 @@ This file contains per-developer preferences that should NOT be committed:
 {
   "workflows": {
     "issue": {
-      "permissionMode": "acceptEdits"
+      "permissionMode": "acceptEdits",
+      "startTerminal": false,
+      "startIde": false
     }
   }
 }
 ```
+
+> **Why `startTerminal: false` and `startIde: false`?**
+> These prevent iloom from opening terminal windows and VS Code/IDE when creating looms. For AI agents operating autonomously, launching GUI applications is disruptive and unnecessary. Setting these in `settings.local.json` means you don't need to pass `--no-code` or `--no-terminal` on every `il start` command. The CLI flags (`--no-code`, `--no-terminal`) still work as a safety net — keep them in your command patterns as a fallback in case settings are missing or overridden.
 
 ### 4. Configure GitHub Remote (Fork Workflows)
 


### PR DESCRIPTION
Adds guidance for AI agents to configure `startTerminal: false` and `startIde: false` in `.iloom/settings.local.json` during project setup. This prevents iloom from launching terminal windows and IDE when creating looms.

CLI flags (`--no-code`, `--no-terminal`) are retained as a safety net fallback in all autonomous command patterns.

**Changes:**
- **SKILL.md**: Added `settings.local.json` creation step to manual setup with `startTerminal: false` and `startIde: false`
- **initialization.md**: Updated Step 3 example and added callout explaining why these settings matter for AI agents

Closes #1